### PR TITLE
feat: refactor drawio tooling for socket-driven xpath workflow

### DIFF
--- a/app/components/chat/constants/toolConstants.ts
+++ b/app/components/chat/constants/toolConstants.ts
@@ -3,9 +3,8 @@
  */
 
 export const TOOL_LABELS: Record<string, string> = {
-  "tool-get_drawio_xml": "获取 DrawIO XML",
-  "tool-replace_drawio_xml": "完全替换 DrawIO XML",
-  "tool-batch_replace_drawio_xml": "批量替换 DrawIO XML",
+  "tool-drawio_read": "读取 DrawIO XML",
+  "tool-drawio_edit_batch": "批量编辑 DrawIO XML",
 };
 
 export const TOOL_STATUS_META: Record<

--- a/app/hooks/useDrawioSocket.ts
+++ b/app/hooks/useDrawioSocket.ts
@@ -14,11 +14,9 @@ import type {
   ServerToClientEvents,
   ClientToServerEvents,
 } from '@/app/types/socket-protocol';
-import type { Replacement } from '@/app/types/drawio-tools';
 import {
   getDrawioXML,
   replaceDrawioXML,
-  batchReplaceDrawioXML,
 } from '@/app/lib/drawio-tools';
 
 /**
@@ -75,13 +73,6 @@ export function useDrawioSocket() {
               throw new Error('缺少 drawio_xml 参数');
             }
             result = replaceDrawioXML(request.input.drawio_xml as string) as unknown as { success: boolean; error?: string; message?: string; [key: string]: unknown };
-            break;
-
-          case 'batch_replace_drawio_xml':
-            if (!request.input?.replacements) {
-              throw new Error('缺少 replacements 参数');
-            }
-            result = batchReplaceDrawioXML(request.input.replacements as Replacement[]) as unknown as { success: boolean; error?: string; message?: string; [key: string]: unknown };
             break;
 
           default:

--- a/app/lib/drawio-ai-tools.ts
+++ b/app/lib/drawio-ai-tools.ts
@@ -1,57 +1,98 @@
 import { tool } from 'ai';
 import { z } from 'zod';
-import { executeToolOnClient } from './tool-executor';
 
-/**
- * 工具 1: 获取 DrawIO XML
- * 获取当前 DrawIO 图表的完整 XML 内容
- */
-export const getDrawioXMLTool = tool({
-  description: '获取当前 DrawIO 图表的完整 XML 内容。使用场景：需要查看当前图表结构时调用此工具。',
-  inputSchema: z.object({}),
-  execute: async () => {
-    return await executeToolOnClient('get_drawio_xml', {}, 10000);
+import {
+  executeDrawioEditBatch,
+  executeDrawioRead,
+} from './drawio-xml-service';
+import type { DrawioEditOperation } from '@/app/types/drawio-tools';
+
+const xpathSchema = z.string().min(1, 'XPath 表达式不能为空');
+
+const setAttributeSchema = z.object({
+  type: z.literal('set_attribute'),
+  xpath: xpathSchema,
+  key: z.string().min(1, '属性名不能为空'),
+  value: z.string(),
+  allow_no_match: z.boolean().optional(),
+});
+
+const removeAttributeSchema = z.object({
+  type: z.literal('remove_attribute'),
+  xpath: xpathSchema,
+  key: z.string().min(1, '属性名不能为空'),
+  allow_no_match: z.boolean().optional(),
+});
+
+const insertElementSchema = z.object({
+  type: z.literal('insert_element'),
+  target_xpath: xpathSchema,
+  new_xml: z.string().min(1, 'new_xml 不能为空'),
+  position: z
+    .enum(['append_child', 'prepend_child', 'before', 'after'])
+    .optional(),
+  allow_no_match: z.boolean().optional(),
+});
+
+const removeElementSchema = z.object({
+  type: z.literal('remove_element'),
+  xpath: xpathSchema,
+  allow_no_match: z.boolean().optional(),
+});
+
+const replaceElementSchema = z.object({
+  type: z.literal('replace_element'),
+  xpath: xpathSchema,
+  new_xml: z.string().min(1, 'new_xml 不能为空'),
+  allow_no_match: z.boolean().optional(),
+});
+
+const setTextContentSchema = z.object({
+  type: z.literal('set_text_content'),
+  xpath: xpathSchema,
+  value: z.string(),
+  allow_no_match: z.boolean().optional(),
+});
+
+const operationSchema = z.union([
+  setAttributeSchema,
+  removeAttributeSchema,
+  insertElementSchema,
+  removeElementSchema,
+  replaceElementSchema,
+  setTextContentSchema,
+]);
+
+export const drawioReadTool = tool({
+  description:
+    '使用 XPath 精确读取 DrawIO XML 内容。默认返回根节点，可传入 xpath 参数精确查询元素、属性或文本。',
+  inputSchema: z
+    .object({
+      xpath: z.string().optional(),
+    })
+    .optional(),
+  execute: async (input) => {
+    const xpath = input?.xpath?.trim();
+    return await executeDrawioRead(xpath);
   },
 });
 
-/**
- * 工具 2: 完全替换 DrawIO XML
- * 完全替换当前 DrawIO 图表的 XML 内容
- */
-export const replaceDrawioXMLTool = tool({
-  description: '完全替换当前 DrawIO 图表的 XML 内容。使用场景：需要生成全新的图表或进行大范围修改时使用。注意：此操作会覆盖整个图表。',
+export const drawioEditBatchTool = tool({
+  description:
+    '基于 XPath 的原子化批量编辑工具。所有操作要么全部成功，要么在任意一步失败时回滚并返回错误。',
   inputSchema: z.object({
-    drawio_xml: z.string().describe('新的完整 DrawIO XML 内容，必须是合法的 XML 格式'),
+    operations: z
+      .array(operationSchema)
+      .min(1, 'operations 至少包含一项操作'),
   }),
-  execute: async ({ drawio_xml }) => {
-    return await executeToolOnClient('replace_drawio_xml', { drawio_xml }, 30000);
+  execute: async ({ operations }) => {
+    return await executeDrawioEditBatch({
+      operations: operations as DrawioEditOperation[],
+    });
   },
 });
 
-/**
- * 工具 3: 批量替换 DrawIO XML
- * 批量精准替换 DrawIO XML 中的内容片段
- */
-export const batchReplaceDrawioXMLTool = tool({
-  description: '批量精准替换 DrawIO XML 中的内容片段。使用场景：需要修改图表中的特定文本、属性或样式时使用。会替换所有匹配的内容（全局替换）。建议先使用 get_drawio_xml 获取内容，确认要替换的字符串正确后再调用。',
-  inputSchema: z.object({
-    replacements: z.array(
-      z.object({
-        search: z.string().describe('要搜索的字符串，将替换所有匹配项'),
-        replace: z.string().describe('替换后的字符串'),
-      })
-    ).describe('替换对数组，每个对象包含 search 和 replace 字段'),
-  }),
-  execute: async ({ replacements }) => {
-    return await executeToolOnClient('batch_replace_drawio_xml', { replacements }, 30000);
-  },
-});
-
-/**
- * 所有 DrawIO 工具的集合，用于传递给 AI SDK
- */
 export const drawioTools = {
-  get_drawio_xml: getDrawioXMLTool,
-  replace_drawio_xml: replaceDrawioXMLTool,
-  batch_replace_drawio_xml: batchReplaceDrawioXMLTool,
+  drawio_read: drawioReadTool,
+  drawio_edit_batch: drawioEditBatchTool,
 };

--- a/app/lib/drawio-tools.ts
+++ b/app/lib/drawio-tools.ts
@@ -1,18 +1,14 @@
 /**
- * DrawIO XML 操作工具集
+ * DrawIO XML 前端存储工具集
  *
- * 提供三个核心功能：
- * 1. getDrawioXML - 获取当前 XML 内容
- * 2. replaceDrawioXML - 覆写 XML 内容
- * 3. batchReplaceDrawioXML - 批量替换 XML 内容
+ * 负责在浏览器环境下管理图表 XML 的持久化与事件分发。
+ * 工具函数会在写入 localStorage 前自动处理 base64 编码的内容，
+ * 并在更新后通过自定义事件通知编辑器重新加载。
  */
 
 import type {
   GetXMLResult,
   ReplaceXMLResult,
-  BatchReplaceResult,
-  Replacement,
-  ReplacementError,
   XMLValidationResult,
 } from "../types/drawio-tools";
 
@@ -22,7 +18,7 @@ import type {
 const STORAGE_KEY = "currentDiagram";
 
 /**
- * 自定义事件名称��用于通知编辑器重新加载
+ * 自定义事件名称，用于通知编辑器重新加载
  */
 const UPDATE_EVENT = "drawio-xml-updated";
 
@@ -64,22 +60,20 @@ function validateXML(xml: string): XMLValidationResult {
  * @returns 解码后的 XML 字符串，如果不是 base64 格式则返回原始内容
  */
 function decodeBase64XML(xml: string): string {
-  const prefix = 'data:image/svg+xml;base64,';
+  const prefix = "data:image/svg+xml;base64,";
 
   if (xml.startsWith(prefix)) {
     try {
-      // 提取 base64 部分
       const base64Content = xml.substring(prefix.length);
-      // 解码 base64
       const decoded = atob(base64Content);
       return decoded;
     } catch (error) {
-      console.error('[DrawIO Tools] Base64 解码失败:', error);
-      return xml; // 解码失败时返回原始内容
+      console.error("[DrawIO Tools] Base64 解码失败:", error);
+      return xml;
     }
   }
 
-  return xml; // 不是 base64 格式，直接返回
+  return xml;
 }
 
 /**
@@ -91,16 +85,11 @@ function decodeBase64XML(xml: string): string {
  */
 export function saveDrawioXML(xml: string): void {
   if (typeof window === "undefined") {
-    throw new Error('saveDrawioXML 只能在浏览器环境中使用');
+    throw new Error("saveDrawioXML 只能在浏览器环境中使用");
   }
 
-  // 自动解码 base64（如果是base64格式）
   const decodedXml = decodeBase64XML(xml);
-
-  // 写入 localStorage（纯XML）
   localStorage.setItem(STORAGE_KEY, decodedXml);
-
-  // 触发更新事件
   triggerUpdateEvent(decodedXml);
 }
 
@@ -120,17 +109,7 @@ function triggerUpdateEvent(xml: string): void {
 }
 
 /**
- * 1. 获取当前 DrawIO XML 内容
- *
- * @returns 包含 XML 内容或错误信息的结果对象
- *
- * @example
- * const result = getDrawioXML();
- * if (result.success) {
- *   console.log(result.xml);
- * } else {
- *   console.error(result.error);
- * }
+ * 获取当前 DrawIO XML 内容
  */
 export function getDrawioXML(): GetXMLResult {
   if (typeof window === "undefined") {
@@ -150,7 +129,6 @@ export function getDrawioXML(): GetXMLResult {
       };
     }
 
-    // 解码 base64 编码的 XML（如果需要）
     const decodedXml = decodeBase64XML(xml);
 
     return {
@@ -166,20 +144,7 @@ export function getDrawioXML(): GetXMLResult {
 }
 
 /**
- * 2. 覆写 DrawIO XML 内容
- *
- * 验证 XML 格式后，将新内容写入 localStorage 并触发重新加载事件
- *
- * @param drawio_xml - 新的 XML 内容
- * @returns 操作结果
- *
- * @example
- * const result = replaceDrawioXML('<mxfile>...</mxfile>');
- * if (result.success) {
- *   console.log('XML 已成功替换');
- * } else {
- *   console.error(result.error);
- * }
+ * 覆写 DrawIO XML 内容
  */
 export function replaceDrawioXML(drawio_xml: string): ReplaceXMLResult {
   if (typeof window === "undefined") {
@@ -190,7 +155,6 @@ export function replaceDrawioXML(drawio_xml: string): ReplaceXMLResult {
     };
   }
 
-  // 验证 XML 格式
   const validation = validateXML(drawio_xml);
   if (!validation.valid) {
     return {
@@ -201,7 +165,6 @@ export function replaceDrawioXML(drawio_xml: string): ReplaceXMLResult {
   }
 
   try {
-    // 保存到 localStorage（自动解码 base64）
     saveDrawioXML(drawio_xml);
 
     return {
@@ -217,159 +180,4 @@ export function replaceDrawioXML(drawio_xml: string): ReplaceXMLResult {
   }
 }
 
-/**
- * 3. 批量精准替换 XML 内容
- *
- * 对每个 search-replace 对进行全局替换，替换所有匹配的内容
- *
- * @param replacements - 替换对数组，每个对象包含 search 和 replace 字段
- * @returns 详细的批量替换结果报告
- *
- * @example
- * const result = batchReplaceDrawioXML([
- *   { search: 'oldText1', replace: 'newText1' },
- *   { search: 'oldText2', replace: 'newText2' }
- * ]);
- * console.log(`成功替换 ${result.successCount} 条`);
- * result.errors.forEach(err => console.log(`错误: ${err.reason}`));
- */
-export function batchReplaceDrawioXML(
-  replacements: Replacement[]
-): BatchReplaceResult {
-  if (typeof window === "undefined") {
-    return {
-      success: false,
-      message: "此函数只能在浏览器环境中使用",
-      totalRequested: replacements.length,
-      successCount: 0,
-      skippedCount: replacements.length,
-      errors: replacements.map((r, i) => ({
-        index: i,
-        search: r.search,
-        replace: r.replace,
-        reason: "不支持服务端环境",
-      })),
-    };
-  }
-
-  // 获取当前 XML
-  const getResult = getDrawioXML();
-  if (!getResult.success || !getResult.xml) {
-    return {
-      success: false,
-      message: getResult.error || "获取当前 XML 失败",
-      totalRequested: replacements.length,
-      successCount: 0,
-      skippedCount: replacements.length,
-      errors: replacements.map((r, i) => ({
-        index: i,
-        search: r.search,
-        replace: r.replace,
-        reason: "无法获取当前 XML 内容",
-      })),
-    };
-  }
-
-  let currentXml = getResult.xml;
-  const errors: ReplacementError[] = [];
-  let successCount = 0;
-
-  // 执行全局替换
-  replacements.forEach((replacement, index) => {
-    const { search, replace } = replacement;
-
-    // 检查搜索内容是否存在
-    if (!currentXml.includes(search)) {
-      errors.push({
-        index,
-        search,
-        replace,
-        reason: `未找到搜索内容 "${search}"`,
-      });
-      return;
-    }
-
-    // 使用全局替换替换所有匹配项
-    const regex = new RegExp(escapeRegExp(search), "g");
-    currentXml = currentXml.replace(regex, replace);
-    successCount++;
-  });
-
-  // 验证替换后的 XML 格式
-  if (successCount > 0) {
-    const validation = validateXML(currentXml);
-    if (!validation.valid) {
-      return {
-        success: false,
-        message: "替换后的 XML 格式验证失败",
-        totalRequested: replacements.length,
-        successCount: 0,
-        skippedCount: replacements.length,
-        errors: [
-          {
-            index: -1,
-            search: "",
-            replace: "",
-            reason: `XML 验证失败: ${validation.error}`,
-          },
-          ...errors,
-        ],
-      };
-    }
-
-    // 保存到 localStorage（自动解码 base64）并触发更新事件
-    try {
-      saveDrawioXML(currentXml);
-    } catch (error) {
-      return {
-        success: false,
-        message: "保存失败",
-        totalRequested: replacements.length,
-        successCount: 0,
-        skippedCount: replacements.length,
-        errors: [
-          {
-            index: -1,
-            search: "",
-            replace: "",
-            reason:
-              error instanceof Error ? error.message : "写入数据失败",
-          },
-          ...errors,
-        ],
-      };
-    }
-  }
-
-  // 生成结果报告
-  const skippedCount = errors.length;
-  const allSuccess = skippedCount === 0 && successCount > 0;
-
-  return {
-    success: allSuccess,
-    message: allSuccess
-      ? `成功替换 ${successCount} 条`
-      : successCount > 0
-      ? `部分成功：成功替换 ${successCount} 条，失败 ${skippedCount} 条`
-      : `所有替换均失败，失败 ${skippedCount} 条`,
-    totalRequested: replacements.length,
-    successCount,
-    skippedCount,
-    errors,
-  };
-}
-
-/**
- * 辅助函数：转义正则表达式特殊字符
- *
- * @param string - 需要转义的字符串
- * @returns 转义后的字符串
- */
-function escapeRegExp(string: string): string {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-/**
- * 导出事件名称常量，供组件监听使用
- */
 export { UPDATE_EVENT };

--- a/app/lib/drawio-xml-service.ts
+++ b/app/lib/drawio-xml-service.ts
@@ -1,0 +1,467 @@
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
+import { select } from 'xpath';
+
+import { executeToolOnClient } from './tool-executor';
+import type {
+  DrawioEditBatchRequest,
+  DrawioEditBatchResult,
+  DrawioEditOperation,
+  DrawioQueryResult,
+  DrawioReadResult,
+  InsertElementOperation,
+  InsertPosition,
+  ReplaceElementOperation,
+  SetAttributeOperation,
+  SetTextContentOperation,
+  RemoveAttributeOperation,
+  RemoveElementOperation,
+} from '@/app/types/drawio-tools';
+import type {
+  GetXMLResult,
+  ReplaceXMLResult,
+} from '@/app/types/drawio-tools';
+
+const BASE64_PREFIX = 'data:image/svg+xml;base64,';
+
+export async function executeDrawioRead(xpathExpression?: string): Promise<DrawioReadResult> {
+  try {
+    const xml = await fetchDiagramXml();
+    const document = parseXml(xml);
+
+    if (!xpathExpression || xpathExpression.trim() === '') {
+      const element = document.documentElement;
+      if (!element) {
+        return {
+          success: true,
+          results: [],
+        };
+      }
+      const rootResult = convertNodeToResult(element);
+      return {
+        success: true,
+        results: rootResult ? [rootResult] : [],
+      };
+    }
+
+    let evaluation;
+    try {
+      evaluation = select(xpathExpression, document);
+    } catch (error) {
+      return {
+        success: false,
+        error: `Invalid XPath expression: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+
+    if (!Array.isArray(evaluation)) {
+      const scalar = toScalarString(evaluation);
+      return {
+        success: true,
+        results: scalar !== undefined ? [{ type: 'text', value: scalar }] : [],
+      };
+    }
+
+    const results: DrawioQueryResult[] = [];
+    for (const node of evaluation) {
+      if (isDomNode(node)) {
+        const converted = convertNodeToResult(node);
+        if (converted) {
+          results.push(converted);
+        }
+      }
+    }
+
+    return {
+      success: true,
+      results,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : '未知错误',
+    };
+  }
+}
+
+export async function executeDrawioEditBatch(
+  request: DrawioEditBatchRequest
+): Promise<DrawioEditBatchResult> {
+  const { operations } = request;
+
+  if (!operations.length) {
+    return {
+      success: true,
+      operations_applied: 0,
+    };
+  }
+
+  let document: Document;
+
+  try {
+    const xml = await fetchDiagramXml();
+    document = parseXml(xml);
+  } catch (error) {
+    return {
+      success: false,
+      operation_index: 0,
+      error: error instanceof Error ? error.message : '无法获取当前图表 XML',
+    };
+  }
+
+  for (let index = 0; index < operations.length; index++) {
+    const operation = operations[index];
+    try {
+      applyOperation(document, operation);
+    } catch (error) {
+      return {
+        success: false,
+        operation_index: index,
+        error: error instanceof Error ? error.message : '未知错误',
+      };
+    }
+  }
+
+  const serializer = new XMLSerializer();
+  const updatedXml = serializer.serializeToString(document);
+
+  const replaceResult = (await executeToolOnClient(
+    'replace_drawio_xml',
+    { drawio_xml: updatedXml },
+    30000
+  )) as ReplaceXMLResult;
+
+  if (!replaceResult?.success) {
+    return {
+      success: false,
+      operation_index: operations.length,
+      error:
+        replaceResult?.error ||
+        replaceResult?.message ||
+        '前端替换 XML 失败',
+    };
+  }
+
+  return {
+    success: true,
+    operations_applied: operations.length,
+  };
+}
+
+async function fetchDiagramXml(): Promise<string> {
+  const response = (await executeToolOnClient(
+    'get_drawio_xml',
+    {},
+    15000
+  )) as GetXMLResult;
+
+  if (!response?.success || typeof response.xml !== 'string') {
+    throw new Error(response?.error || '无法获取当前 DrawIO XML');
+  }
+
+  return decodeDiagramXml(response.xml);
+}
+
+function decodeDiagramXml(payload: string): string {
+  const trimmed = payload.trim();
+
+  if (trimmed.startsWith('<')) {
+    return trimmed;
+  }
+
+  let base64Content = trimmed;
+  if (trimmed.startsWith(BASE64_PREFIX)) {
+    base64Content = trimmed.slice(BASE64_PREFIX.length);
+  }
+
+  try {
+    const decoded = Buffer.from(base64Content, 'base64').toString('utf-8');
+    if (!decoded.trim().startsWith('<')) {
+      throw new Error('解码结果不是合法的 XML');
+    }
+    return decoded;
+  } catch (error) {
+    throw new Error(
+      error instanceof Error
+        ? `Base64 解码失败: ${error.message}`
+        : 'Base64 解码失败'
+    );
+  }
+}
+
+function parseXml(xml: string): Document {
+  const parser = new DOMParser();
+  const document = parser.parseFromString(xml, 'text/xml');
+  const parseErrors = document.getElementsByTagName('parsererror');
+  if (parseErrors.length > 0) {
+    throw new Error(parseErrors[0].textContent || 'XML 解析失败');
+  }
+  return document;
+}
+
+function convertNodeToResult(node: Node): DrawioQueryResult | null {
+  const serializer = new XMLSerializer();
+
+  switch (node.nodeType) {
+    case node.ELEMENT_NODE: {
+      const element = node as Element;
+      const attributes: Record<string, string> = {};
+      for (let i = 0; i < element.attributes.length; i++) {
+        const attribute = element.attributes.item(i);
+        if (attribute) {
+          attributes[attribute.name] = attribute.value;
+        }
+      }
+      return {
+        type: 'element',
+        tag_name: element.tagName,
+        attributes,
+        xml_string: serializer.serializeToString(element),
+      };
+    }
+    case node.ATTRIBUTE_NODE: {
+      const attr = node as Attr;
+      return {
+        type: 'attribute',
+        name: attr.name,
+        value: attr.value,
+      };
+    }
+    case node.TEXT_NODE: {
+      return {
+        type: 'text',
+        value: node.nodeValue ?? '',
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+function applyOperation(document: Document, operation: DrawioEditOperation): void {
+  switch (operation.type) {
+    case 'set_attribute':
+      setAttribute(document, operation);
+      break;
+    case 'remove_attribute':
+      removeAttribute(document, operation);
+      break;
+    case 'insert_element':
+      insertElement(document, operation);
+      break;
+    case 'remove_element':
+      removeElement(document, operation);
+      break;
+    case 'replace_element':
+      replaceElement(document, operation);
+      break;
+    case 'set_text_content':
+      setTextContent(document, operation);
+      break;
+    default:
+      throw new Error(`未知操作类型: ${(operation as { type: string }).type}`);
+  }
+}
+
+function setAttribute(document: Document, operation: SetAttributeOperation): void {
+  const nodes = selectNodes(document, operation.xpath);
+
+  if (nodes.length === 0) {
+    if (operation.allow_no_match) {
+      return;
+    }
+    throw new Error(`XPath '${operation.xpath}' did not match any elements.`);
+  }
+
+  for (const node of nodes) {
+    if (node.nodeType !== node.ELEMENT_NODE) {
+      throw new Error(`XPath '${operation.xpath}' 匹配的节点不是元素。`);
+    }
+    (node as Element).setAttribute(operation.key, operation.value);
+  }
+}
+
+function removeAttribute(document: Document, operation: RemoveAttributeOperation): void {
+  const nodes = selectNodes(document, operation.xpath);
+
+  if (nodes.length === 0) {
+    if (operation.allow_no_match) {
+      return;
+    }
+    throw new Error(`XPath '${operation.xpath}' did not match any elements.`);
+  }
+
+  for (const node of nodes) {
+    if (node.nodeType !== node.ELEMENT_NODE) {
+      throw new Error(`XPath '${operation.xpath}' 匹配的节点不是元素。`);
+    }
+    (node as Element).removeAttribute(operation.key);
+  }
+}
+
+function insertElement(document: Document, operation: InsertElementOperation): void {
+  const targets = selectNodes(document, operation.target_xpath);
+
+  if (targets.length === 0) {
+    if (operation.allow_no_match) {
+      return;
+    }
+    throw new Error(`XPath '${operation.target_xpath}' did not match any elements.`);
+  }
+
+  const position: InsertPosition = operation.position ?? 'append_child';
+
+  for (const target of targets) {
+    const newNode = createElementFromXml(document, operation.new_xml);
+
+    switch (position) {
+      case 'append_child': {
+        if (target.nodeType !== target.ELEMENT_NODE) {
+          throw new Error(`XPath '${operation.target_xpath}' 仅支持元素节点作为父节点。`);
+        }
+        (target as Element).appendChild(newNode);
+        break;
+      }
+      case 'prepend_child': {
+        if (target.nodeType !== target.ELEMENT_NODE) {
+          throw new Error(`XPath '${operation.target_xpath}' 仅支持元素节点作为父节点。`);
+        }
+        const element = target as Element;
+        element.insertBefore(newNode, element.firstChild);
+        break;
+      }
+      case 'before': {
+        const parent = target.parentNode;
+        if (!parent) {
+          throw new Error('目标节点没有父节点，无法执行 before 插入。');
+        }
+        parent.insertBefore(newNode, target);
+        break;
+      }
+      case 'after': {
+        const parent = target.parentNode;
+        if (!parent) {
+          throw new Error('目标节点没有父节点，无法执行 after 插入。');
+        }
+        parent.insertBefore(newNode, target.nextSibling);
+        break;
+      }
+      default:
+        throw new Error(`未知的插入位置: ${String(position)}`);
+    }
+  }
+}
+
+function removeElement(document: Document, operation: RemoveElementOperation): void {
+  const nodes = selectNodes(document, operation.xpath);
+
+  if (nodes.length === 0) {
+    if (operation.allow_no_match) {
+      return;
+    }
+    throw new Error(`XPath '${operation.xpath}' did not match any elements.`);
+  }
+
+  for (const node of nodes) {
+    const parent = node.parentNode;
+    if (!parent) {
+      throw new Error('无法删除根节点。');
+    }
+    parent.removeChild(node);
+  }
+}
+
+function replaceElement(document: Document, operation: ReplaceElementOperation): void {
+  const nodes = selectNodes(document, operation.xpath);
+
+  if (nodes.length === 0) {
+    if (operation.allow_no_match) {
+      return;
+    }
+    throw new Error(`XPath '${operation.xpath}' did not match any elements.`);
+  }
+
+  for (const node of nodes) {
+    const parent = node.parentNode;
+    if (!parent) {
+      throw new Error('无法替换根节点。');
+    }
+    const replacement = createElementFromXml(document, operation.new_xml);
+    parent.replaceChild(replacement, node);
+  }
+}
+
+function setTextContent(document: Document, operation: SetTextContentOperation): void {
+  const nodes = selectNodes(document, operation.xpath);
+
+  if (nodes.length === 0) {
+    if (operation.allow_no_match) {
+      return;
+    }
+    throw new Error(`XPath '${operation.xpath}' did not match any elements.`);
+  }
+
+  for (const node of nodes) {
+    if (node.nodeType !== node.ELEMENT_NODE) {
+      throw new Error(`XPath '${operation.xpath}' 匹配的节点不是元素。`);
+    }
+
+    const element = node as Element;
+    while (element.firstChild) {
+      element.removeChild(element.firstChild);
+    }
+    element.appendChild(document.createTextNode(operation.value));
+  }
+}
+
+function createElementFromXml(document: Document, xml: string): Element {
+  const parser = new DOMParser();
+  const fragment = parser.parseFromString(xml, 'text/xml');
+  const parseErrors = fragment.getElementsByTagName('parsererror');
+  if (parseErrors.length > 0) {
+    throw new Error(parseErrors[0].textContent || 'new_xml 解析失败');
+  }
+  const element = fragment.documentElement;
+  if (!element) {
+    throw new Error('new_xml 必须包含一个元素节点');
+  }
+
+  if (typeof document.importNode === 'function') {
+    return document.importNode(element, true) as Element;
+  }
+
+  return element.cloneNode(true) as Element;
+}
+
+function selectNodes(document: Document, expression: string): Node[] {
+  let evaluation;
+  try {
+    evaluation = select(expression, document);
+  } catch (error) {
+    throw new Error(
+      `Invalid XPath expression: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  if (!Array.isArray(evaluation)) {
+    return [];
+  }
+
+  return evaluation.filter(isDomNode);
+}
+
+function isDomNode(value: unknown): value is Node {
+  return Boolean(value && typeof (value as Node).nodeType === 'number');
+}
+
+function toScalarString(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (isDomNode(value)) {
+    return value.textContent ?? undefined;
+  }
+  return undefined;
+}

--- a/app/types/drawio-tools.ts
+++ b/app/types/drawio-tools.ts
@@ -3,7 +3,7 @@
  */
 
 /**
- * 获取 XML 的返回结果
+ * 获取 XML 的返回结果（前端存储访问）
  */
 export interface GetXMLResult {
   success: boolean;
@@ -12,7 +12,7 @@ export interface GetXMLResult {
 }
 
 /**
- * 替换 XML 的返回结果
+ * 替换 XML 的返回结果（前端存储访问）
  */
 export interface ReplaceXMLResult {
   success: boolean;
@@ -21,39 +21,118 @@ export interface ReplaceXMLResult {
 }
 
 /**
- * 批量替换的单个替换对
- */
-export interface Replacement {
-  search: string;
-  replace: string;
-}
-
-/**
- * 批量替换中失败项的错误详情
- */
-export interface ReplacementError {
-  index: number;
-  search: string;
-  replace: string;
-  reason: string;
-}
-
-/**
- * 批量替换的返回结果
- */
-export interface BatchReplaceResult {
-  success: boolean;
-  message: string;
-  totalRequested: number;
-  successCount: number;
-  skippedCount: number;
-  errors: ReplacementError[];
-}
-
-/**
  * XML 验证结果
  */
 export interface XMLValidationResult {
   valid: boolean;
   error?: string;
+}
+
+/**
+ * drawio_read 查询结果的统一类型
+ */
+export type DrawioQueryResult =
+  | DrawioElementResult
+  | DrawioAttributeResult
+  | DrawioTextResult;
+
+export interface DrawioElementResult {
+  type: 'element';
+  tag_name: string;
+  attributes: Record<string, string>;
+  xml_string: string;
+}
+
+export interface DrawioAttributeResult {
+  type: 'attribute';
+  name: string;
+  value: string;
+}
+
+export interface DrawioTextResult {
+  type: 'text';
+  value: string;
+}
+
+export interface DrawioReadResult {
+  success: boolean;
+  results?: DrawioQueryResult[];
+  error?: string;
+}
+
+/**
+ * drawio_edit_batch 批量操作定义
+ */
+interface OperationBase {
+  allow_no_match?: boolean;
+}
+
+export interface SetAttributeOperation extends OperationBase {
+  type: 'set_attribute';
+  xpath: string;
+  key: string;
+  value: string;
+}
+
+export interface RemoveAttributeOperation extends OperationBase {
+  type: 'remove_attribute';
+  xpath: string;
+  key: string;
+}
+
+export type InsertPosition =
+  | 'append_child'
+  | 'prepend_child'
+  | 'before'
+  | 'after';
+
+export interface InsertElementOperation extends OperationBase {
+  type: 'insert_element';
+  target_xpath: string;
+  new_xml: string;
+  position?: InsertPosition;
+}
+
+export interface RemoveElementOperation extends OperationBase {
+  type: 'remove_element';
+  xpath: string;
+}
+
+export interface ReplaceElementOperation extends OperationBase {
+  type: 'replace_element';
+  xpath: string;
+  new_xml: string;
+}
+
+export interface SetTextContentOperation extends OperationBase {
+  type: 'set_text_content';
+  xpath: string;
+  value: string;
+}
+
+export type DrawioEditOperation =
+  | SetAttributeOperation
+  | RemoveAttributeOperation
+  | InsertElementOperation
+  | RemoveElementOperation
+  | ReplaceElementOperation
+  | SetTextContentOperation;
+
+export interface DrawioEditBatchRequest {
+  operations: DrawioEditOperation[];
+}
+
+export type DrawioEditBatchResult =
+  | DrawioEditBatchSuccess
+  | DrawioEditBatchError;
+
+export interface DrawioEditBatchSuccess {
+  success: true;
+  operations_applied: number;
+}
+
+export interface DrawioEditBatchError {
+  success: false;
+  operation_index: number;
+  error: string;
 }

--- a/app/types/global.d.ts
+++ b/app/types/global.d.ts
@@ -46,4 +46,15 @@ declare global {
   }
 }
 
+declare module 'xpath' {
+  import type { Document, Node } from '@xmldom/xmldom';
+
+  export type XPathValue = Node | string | number | boolean;
+
+  export function select(
+    expression: string,
+    node: Node | Document
+  ): XPathValue | XPathValue[];
+}
+
 export {};

--- a/app/types/socket-protocol.ts
+++ b/app/types/socket-protocol.ts
@@ -9,7 +9,7 @@
  */
 export interface ToolCallRequest {
   requestId: string;
-  toolName: 'get_drawio_xml' | 'replace_drawio_xml' | 'batch_replace_drawio_xml';
+  toolName: 'get_drawio_xml' | 'replace_drawio_xml';
   input: Record<string, unknown>;
   timeout: number;
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@heroui/react": "3.0.0-alpha.35",
     "@heroui/styles": "3.0.0-alpha.35",
     "@tailwindcss/postcss": "^4.1.16",
+    "@xmldom/xmldom": "^0.8.11",
     "ai": "^5.0.86",
     "electron-store": "^11.0.2",
     "next": "^15.5.6",
@@ -41,6 +42,7 @@
     "tailwind-variants": "^3.1.1",
     "tailwindcss": "^4.1.16",
     "uuid": "^11.0.6",
+    "xpath": "^0.0.34",
     "zod": "^4.1.12"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.1.16
         version: 4.1.16
+      '@xmldom/xmldom':
+        specifier: ^0.8.11
+        version: 0.8.11
       ai:
         specifier: ^5.0.86
         version: 5.0.86(zod@4.1.12)
@@ -68,6 +71,9 @@ importers:
       uuid:
         specifier: ^11.0.6
         version: 11.1.0
+      xpath:
+        specifier: ^0.0.34
+        version: 0.0.34
       zod:
         specifier: ^4.1.12
         version: 4.1.12
@@ -3925,6 +3931,10 @@ packages:
   xmlhttprequest-ssl@2.1.2:
     resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
     engines: {node: '>=0.4.0'}
+
+  xpath@0.0.34:
+    resolution: {integrity: sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA==}
+    engines: {node: '>=0.6.0'}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -8934,6 +8944,8 @@ snapshots:
   xmlbuilder@15.1.1: {}
 
   xmlhttprequest-ssl@2.1.2: {}
+
+  xpath@0.0.34: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## Summary
- implement a server-side DrawIO XML service that decodes base64 payloads, runs XPath-driven reads/edits, and writes updates back via Socket.IO
- replace the old tool set with drawio_read and drawio_edit_batch plus revised schemas, client storage helpers, and chat labels
- refresh shared types/docs and add the @xmldom/xmldom + xpath dependencies needed for DOM manipulation

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_6909c5f835548328aec57e35811fc0a5