### PR TITLE
fix: update drawio tooling prompt and schema

### DIFF
--- a/app/components/chat/constants/toolConstants.ts
+++ b/app/components/chat/constants/toolConstants.ts
@@ -3,9 +3,8 @@
  */
 
 export const TOOL_LABELS: Record<string, string> = {
-  "tool-get_drawio_xml": "获取 DrawIO XML",
-  "tool-replace_drawio_xml": "完全替换 DrawIO XML",
-  "tool-batch_replace_drawio_xml": "批量替换 DrawIO XML",
+  "tool-drawio_read": "读取 DrawIO XML",
+  "tool-drawio_edit_batch": "批量编辑 DrawIO XML",
 };
 
 export const TOOL_STATUS_META: Record<

--- a/app/hooks/useDrawioSocket.ts
+++ b/app/hooks/useDrawioSocket.ts
@@ -14,11 +14,9 @@ import type {
   ServerToClientEvents,
   ClientToServerEvents,
 } from '@/app/types/socket-protocol';
-import type { Replacement } from '@/app/types/drawio-tools';
 import {
   getDrawioXML,
   replaceDrawioXML,
-  batchReplaceDrawioXML,
 } from '@/app/lib/drawio-tools';
 
 /**
@@ -75,13 +73,6 @@ export function useDrawioSocket() {
               throw new Error('缺少 drawio_xml 参数');
             }
             result = replaceDrawioXML(request.input.drawio_xml as string) as unknown as { success: boolean; error?: string; message?: string; [key: string]: unknown };
-            break;
-
-          case 'batch_replace_drawio_xml':
-            if (!request.input?.replacements) {
-              throw new Error('缺少 replacements 参数');
-            }
-            result = batchReplaceDrawioXML(request.input.replacements as Replacement[]) as unknown as { success: boolean; error?: string; message?: string; [key: string]: unknown };
             break;
 
           default:

--- a/app/lib/AGENTS.md
+++ b/app/lib/AGENTS.md
@@ -2,182 +2,59 @@
 
 ## 概述
 
-汇总应用层工具函数，包括 DrawIO XML 操作、AI 工具调用与 LLM 配置管理，支持跨组件复用。
+汇总应用层工具函数与 AI 工具定义，负责 DrawIO XML 的读取、写入与 Socket.IO 调用协调。
 
 ## 工具文件清单
 
-- **drawio-tools.ts**: DrawIO XML 操作工具集
-- **drawio-ai-tools.ts**: DrawIO AI 工具调用接口
-- **tool-executor.ts**: 工具执行路由器
+- **drawio-tools.ts**: 浏览器端的 XML 存储桥接（localStorage + 事件通知）
+- **drawio-xml-service.ts**: 服务端 XML 转接层，负责 XPath 查询与批量编辑
+- **drawio-ai-tools.ts**: AI 工具定义（`drawio_read` / `drawio_edit_batch`）
+- **tool-executor.ts**: 工具执行路由器，通过 Socket.IO 与前端通讯
 - ~~llm-config.ts~~: LLM 配置工具（已迁移到 hooks）
 
-## DrawIO AI 工具调用（`drawio-ai-tools.ts`）
+## DrawIO Socket.IO 调用流程
 
-AI 工具调用的统一接口，通过 Socket.IO 与前端通讯执行 DrawIO 相关操作。
+1. 后端工具通过 `executeToolOnClient()` 获取当前 XML 或请求前端写入
+2. 前端（`useDrawioSocket` + `drawio-tools.ts`）访问 localStorage 并响应请求
+3. 服务端使用 `drawio-xml-service.ts` 对 XML 进行 XPath 查询或批量操作
+4. 编辑完成后再次通过 Socket.IO 将新 XML 写回前端
 
-### 工具方法
-- `getDiagramData()`: 获取当前图表 XML 数据
-- `updateDiagram(newXml)`: 更新图表 XML 数据
-- `batchReplaceText(replacements)`: 批量替换文本内容
+## DrawIO XML 转接层（`drawio-xml-service.ts`）
 
-### Socket.IO 通讯
-- 通过 `executeToolOnClient()` 发送执行请求到前端
-- 等待前端执行结果并返回
-- 默认30秒超时机制
+### 核心设计原则
+- **无推断 (No Inference)**: 不对 XML 做领域特化解析，只处理调用者提供的 XPath 与原始字符串
+- **XPath 驱动**: 所有查询与编辑均使用标准 XPath 表达式定位节点
+- **原子性**: `drawio_edit_batch` 全部成功后才写回前端，任一操作失败立即返回错误，不修改原始 XML
+- **Base64 解码**: 每次从前端读取 XML 后都会自动检测并解码 `data:image/svg+xml;base64,` 前缀
+
+### 提供的函数
+- `executeDrawioRead(xpath?: string)`: 返回结构化的查询结果（元素 / 属性 / 文本），并在 `matched_xpath` 字段中携带命中路径
+- `executeDrawioEditBatch({ operations })`: 执行批量操作，遵守 `allow_no_match` 语义并保持原子性
+
+### 支持的操作类型
+`set_attribute`, `remove_attribute`, `insert_element`, `remove_element`, `replace_element`, `set_text_content`
+
+## DrawIO AI 工具（`drawio-ai-tools.ts`）
+
+- **`drawio_read`**: 可选 `xpath` 参数，默认返回根节点。输出为结构化 JSON 数组
+- **`drawio_edit_batch`**: `operations` 数组，严格遵循“全部成功或全部失败”规则
+- 输入参数使用 Zod 校验并在内部调用 `drawio-xml-service.ts`
 
 ## 工具执行路由器（`tool-executor.ts`）
 
-统一路由管理所有工具调用，区分前后端执行。
+- 统一管理 Socket.IO 请求的发送与结果回传
+- 自动生成 `requestId`、处理超时与错误
+- 当前仅路由 DrawIO 相关工具（前端执行部分）
 
-### 路由逻辑
-- **前端工具**: DrawIO 相关工具 → Socket.IO → 前端执行
-- **后端工具**: 其他工具 → 直接在 Node.js 环境执行
+## 浏览器端存储工具（`drawio-tools.ts`）
 
-### 支持的工具
-- DrawIO 工具集（前端执行）
-- 预留其他工具接口（后端执行）
-
-## 历史功能：LLM 配置工具（已迁移）
-> ⚠️ 注意：LLM 配置工具已迁移至 `hooks/useLLMConfig.ts`，不再位于此目录
-
-- **默认配置**: `DEFAULT_LLM_CONFIG` 与 `DEFAULT_SYSTEM_PROMPT` 提供统一的初始参数。
-- **URL 规范化**: `normalizeApiUrl` 自动补全 `/v1` 路径并清理尾部斜杠。
-- **供应商识别**: `resolveProviderType`/`isProviderType` 兼容旧版 `useLegacyOpenAIFormat` 配置。
-- **配置归一化**: `normalizeLLMConfig` 输出后端与前端共用的标准化 `LLMConfig`。
-
-## DrawIO XML 工具集（`drawio-tools.ts`）
-
-提供 DrawIO XML 文档操作的完整工具集，支持获取、修改和批量替换 XML 内容。
-
-### 存储管理
-- **存储键**: `currentDiagram`
-- **自动同步**: 修改后立即更新 localStorage
-- **编辑器通知**: 通过事件系统触发重新加载
-
-### 事件系统
-通过自定义事件通知 DrawIO 编辑器重新加载：
-```typescript
-window.dispatchEvent(new CustomEvent("drawio-xml-updated", {
-  detail: { xml: newXml }
-}));
-```
-
-## 核心功能
-
-### 1. getDrawioXML()
-获取当前存储在 localStorage 中的 DrawIO XML 内容。
-
-**返回**:
-```typescript
-GetXMLResult {
-  success: boolean;
-  xml?: string;
-  error?: string;
-}
-```
-
-### 2. replaceDrawioXML(newXml: string)
-安全地覆写当前的 DrawIO XML 内容。
-
-**参数**:
-- `newXml`: 新的 XML 内容字符串
-
-**功能**:
-- XML 格式验证
-- localStorage 更新
-- 编辑器重新加载通知
-
-**返回**:
-```typescript
-ReplaceXMLResult {
-  success: boolean;
-  message: string;
-  error?: string;
-}
-```
-
-### 3. batchReplaceDrawioXML(replacements: Replacement[])
-批量替换 XML 中的文本内容，支持全局替换（替换所有匹配项）。
-
-**参数**:
-- `replacements`: 替换规则数组
-  ```typescript
-  Replacement {
-    search: string;    // 查找文本（将替换所有匹配项）
-    replace: string;   // 替换文本
-  }
-  ```
-
-**功能**:
-- 全局替换所有匹配的内容
-- 自动跳过未找到的搜索内容
-- 详细的错误报告
-
-**返回**:
-```typescript
-BatchReplaceResult {
-  success: boolean;
-  message: string;
-  totalRequested: number;
-  successCount: number;
-  skippedCount: number;
-  errors: ReplacementError[];
-}
-```
-
-## 技术实现
-
-### XML 验证
-使用浏览器内置的 DOMParser 进行 XML 格式验证：
-```typescript
-const parser = new DOMParser();
-const doc = parser.parseFromString(xml, "text/xml");
-const parseError = doc.querySelector("parsererror");
-```
-
-### 事件系统
-通过自定义事件通知 DrawIO 编辑器重新加载：
-```typescript
-window.dispatchEvent(new CustomEvent("drawio-xml-updated", {
-  detail: { xml: newXml }
-}));
-```
-
-### 存储管理
-- **存储键**: `currentDiagram`
-- **自动同步**: 修改后立即更新 localStorage
-- **编辑器通知**: 通过事件系统触发重新加载
-
-## 使用示例
-
-```typescript
-import {
-  getDrawioXML,
-  replaceDrawioXML,
-  batchReplaceDrawioXML
-} from "../lib/drawio-tools";
-
-// 获取当前 XML
-const currentXml = await getDrawioXML();
-
-// 替换整个 XML
-await replaceDrawioXML(newXmlContent);
-
-// 批量文本替换
-await batchReplaceDrawioXML([
-  { search: "旧文本", replace: "新文本" },
-  { search: "另一个旧文本", replace: "另一个新文本" }
-]);
-```
-
-## 错误处理
-
-所有函数都提供详细的错误信息：
-- XML 格式验证错误
-- localStorage 访问错误
-- 批量操作中的单项错误
-- 成功操作的详细统计
+- localStorage 键名：`currentDiagram`
+- 保存时自动解码 base64，并通过 `drawio-xml-updated` 自定义事件通知编辑器
+- 提供 `getDrawioXML()`、`replaceDrawioXML()`、`saveDrawioXML()` 三个接口
 
 ## 类型定义
 
-完整的 TypeScript 类型定义位于 `../types/drawio-tools.ts`，包含所有接口和错误类型。
+所有公共类型位于 `../types/drawio-tools.ts`，包含：
+- 前端桥接返回结果（`GetXMLResult` / `ReplaceXMLResult` / `XMLValidationResult`）
+- `drawio_read` 查询结果结构
+- `drawio_edit_batch` 支持的操作及返回值

--- a/app/lib/drawio-ai-tools.ts
+++ b/app/lib/drawio-ai-tools.ts
@@ -1,57 +1,123 @@
 import { tool } from 'ai';
 import { z } from 'zod';
-import { executeToolOnClient } from './tool-executor';
 
-/**
- * 工具 1: 获取 DrawIO XML
- * 获取当前 DrawIO 图表的完整 XML 内容
- */
-export const getDrawioXMLTool = tool({
-  description: '获取当前 DrawIO 图表的完整 XML 内容。使用场景：需要查看当前图表结构时调用此工具。',
-  inputSchema: z.object({}),
-  execute: async () => {
-    return await executeToolOnClient('get_drawio_xml', {}, 10000);
+import {
+  executeDrawioEditBatch,
+  executeDrawioRead,
+} from './drawio-xml-service';
+import type { DrawioEditOperation } from '@/app/types/drawio-tools';
+
+const operationSchema = z
+  .object({
+    type: z.enum([
+      'set_attribute',
+      'remove_attribute',
+      'insert_element',
+      'remove_element',
+      'replace_element',
+      'set_text_content',
+    ]),
+    xpath: z.string().optional(),
+    target_xpath: z.string().optional(),
+    key: z.string().optional(),
+    value: z.string().optional(),
+    new_xml: z.string().optional(),
+    position: z.enum(['append_child', 'prepend_child', 'before', 'after']).optional(),
+    allow_no_match: z.boolean().optional(),
+  })
+  .superRefine((operation, ctx) => {
+    const ensureNonEmpty = (
+      value: string | undefined,
+      path: (string | number)[],
+      message: string
+    ) => {
+      if (typeof value !== 'string' || value.trim() === '') {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path,
+          message,
+        });
+      }
+    };
+
+    switch (operation.type) {
+      case 'set_attribute': {
+        ensureNonEmpty(operation.xpath, ['xpath'], 'xpath 不能为空');
+        ensureNonEmpty(operation.key, ['key'], 'key 不能为空');
+        if (typeof operation.value !== 'string') {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['value'],
+            message: 'value 必须是字符串',
+          });
+        }
+        break;
+      }
+      case 'remove_attribute': {
+        ensureNonEmpty(operation.xpath, ['xpath'], 'xpath 不能为空');
+        ensureNonEmpty(operation.key, ['key'], 'key 不能为空');
+        break;
+      }
+      case 'insert_element': {
+        ensureNonEmpty(operation.target_xpath, ['target_xpath'], 'target_xpath 不能为空');
+        ensureNonEmpty(operation.new_xml, ['new_xml'], 'new_xml 不能为空');
+        break;
+      }
+      case 'remove_element': {
+        ensureNonEmpty(operation.xpath, ['xpath'], 'xpath 不能为空');
+        break;
+      }
+      case 'replace_element': {
+        ensureNonEmpty(operation.xpath, ['xpath'], 'xpath 不能为空');
+        ensureNonEmpty(operation.new_xml, ['new_xml'], 'new_xml 不能为空');
+        break;
+      }
+      case 'set_text_content': {
+        ensureNonEmpty(operation.xpath, ['xpath'], 'xpath 不能为空');
+        if (typeof operation.value !== 'string') {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['value'],
+            message: 'value 必须是字符串',
+          });
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  });
+
+export const drawioReadTool = tool({
+  description:
+    '使用 XPath 精确读取 DrawIO XML 内容。默认返回根节点，可传入 xpath 参数精确查询元素、属性或文本，结果会包含 matched_xpath 以便后续调用。',
+  inputSchema: z
+    .object({
+      xpath: z.string().optional(),
+    })
+    .optional(),
+  execute: async (input) => {
+    const xpath = input?.xpath?.trim();
+    return await executeDrawioRead(xpath);
   },
 });
 
-/**
- * 工具 2: 完全替换 DrawIO XML
- * 完全替换当前 DrawIO 图表的 XML 内容
- */
-export const replaceDrawioXMLTool = tool({
-  description: '完全替换当前 DrawIO 图表的 XML 内容。使用场景：需要生成全新的图表或进行大范围修改时使用。注意：此操作会覆盖整个图表。',
+export const drawioEditBatchTool = tool({
+  description:
+    '基于 XPath 的原子化批量编辑工具。所有操作要么全部成功，要么在任意一步失败时回滚并返回错误。',
   inputSchema: z.object({
-    drawio_xml: z.string().describe('新的完整 DrawIO XML 内容，必须是合法的 XML 格式'),
+    operations: z
+      .array(operationSchema)
+      .min(1, 'operations 至少包含一项操作'),
   }),
-  execute: async ({ drawio_xml }) => {
-    return await executeToolOnClient('replace_drawio_xml', { drawio_xml }, 30000);
+  execute: async ({ operations }) => {
+    return await executeDrawioEditBatch({
+      operations: operations as DrawioEditOperation[],
+    });
   },
 });
 
-/**
- * 工具 3: 批量替换 DrawIO XML
- * 批量精准替换 DrawIO XML 中的内容片段
- */
-export const batchReplaceDrawioXMLTool = tool({
-  description: '批量精准替换 DrawIO XML 中的内容片段。使用场景：需要修改图表中的特定文本、属性或样式时使用。会替换所有匹配的内容（全局替换）。建议先使用 get_drawio_xml 获取内容，确认要替换的字符串正确后再调用。',
-  inputSchema: z.object({
-    replacements: z.array(
-      z.object({
-        search: z.string().describe('要搜索的字符串，将替换所有匹配项'),
-        replace: z.string().describe('替换后的字符串'),
-      })
-    ).describe('替换对数组，每个对象包含 search 和 replace 字段'),
-  }),
-  execute: async ({ replacements }) => {
-    return await executeToolOnClient('batch_replace_drawio_xml', { replacements }, 30000);
-  },
-});
-
-/**
- * 所有 DrawIO 工具的集合，用于传递给 AI SDK
- */
 export const drawioTools = {
-  get_drawio_xml: getDrawioXMLTool,
-  replace_drawio_xml: replaceDrawioXMLTool,
-  batch_replace_drawio_xml: batchReplaceDrawioXMLTool,
+  drawio_read: drawioReadTool,
+  drawio_edit_batch: drawioEditBatchTool,
 };

--- a/app/lib/drawio-tools.ts
+++ b/app/lib/drawio-tools.ts
@@ -1,18 +1,14 @@
 /**
- * DrawIO XML 操作工具集
+ * DrawIO XML 前端存储工具集
  *
- * 提供三个核心功能：
- * 1. getDrawioXML - 获取当前 XML 内容
- * 2. replaceDrawioXML - 覆写 XML 内容
- * 3. batchReplaceDrawioXML - 批量替换 XML 内容
+ * 负责在浏览器环境下管理图表 XML 的持久化与事件分发。
+ * 工具函数会在写入 localStorage 前自动处理 base64 编码的内容，
+ * 并在更新后通过自定义事件通知编辑器重新加载。
  */
 
 import type {
   GetXMLResult,
   ReplaceXMLResult,
-  BatchReplaceResult,
-  Replacement,
-  ReplacementError,
   XMLValidationResult,
 } from "../types/drawio-tools";
 
@@ -22,7 +18,7 @@ import type {
 const STORAGE_KEY = "currentDiagram";
 
 /**
- * 自定义事件名称��用于通知编辑器重新加载
+ * 自定义事件名称，用于通知编辑器重新加载
  */
 const UPDATE_EVENT = "drawio-xml-updated";
 
@@ -64,22 +60,20 @@ function validateXML(xml: string): XMLValidationResult {
  * @returns 解码后的 XML 字符串，如果不是 base64 格式则返回原始内容
  */
 function decodeBase64XML(xml: string): string {
-  const prefix = 'data:image/svg+xml;base64,';
+  const prefix = "data:image/svg+xml;base64,";
 
   if (xml.startsWith(prefix)) {
     try {
-      // 提取 base64 部分
       const base64Content = xml.substring(prefix.length);
-      // 解码 base64
       const decoded = atob(base64Content);
       return decoded;
     } catch (error) {
-      console.error('[DrawIO Tools] Base64 解码失败:', error);
-      return xml; // 解码失败时返回原始内容
+      console.error("[DrawIO Tools] Base64 解码失败:", error);
+      return xml;
     }
   }
 
-  return xml; // 不是 base64 格式，直接返回
+  return xml;
 }
 
 /**
@@ -91,16 +85,11 @@ function decodeBase64XML(xml: string): string {
  */
 export function saveDrawioXML(xml: string): void {
   if (typeof window === "undefined") {
-    throw new Error('saveDrawioXML 只能在浏览器环境中使用');
+    throw new Error("saveDrawioXML 只能在浏览器环境中使用");
   }
 
-  // 自动解码 base64（如果是base64格式）
   const decodedXml = decodeBase64XML(xml);
-
-  // 写入 localStorage（纯XML）
   localStorage.setItem(STORAGE_KEY, decodedXml);
-
-  // 触发更新事件
   triggerUpdateEvent(decodedXml);
 }
 
@@ -120,17 +109,7 @@ function triggerUpdateEvent(xml: string): void {
 }
 
 /**
- * 1. 获取当前 DrawIO XML 内容
- *
- * @returns 包含 XML 内容或错误信息的结果对象
- *
- * @example
- * const result = getDrawioXML();
- * if (result.success) {
- *   console.log(result.xml);
- * } else {
- *   console.error(result.error);
- * }
+ * 获取当前 DrawIO XML 内容
  */
 export function getDrawioXML(): GetXMLResult {
   if (typeof window === "undefined") {
@@ -150,7 +129,6 @@ export function getDrawioXML(): GetXMLResult {
       };
     }
 
-    // 解码 base64 编码的 XML（如果需要）
     const decodedXml = decodeBase64XML(xml);
 
     return {
@@ -166,20 +144,7 @@ export function getDrawioXML(): GetXMLResult {
 }
 
 /**
- * 2. 覆写 DrawIO XML 内容
- *
- * 验证 XML 格式后，将新内容写入 localStorage 并触发重新加载事件
- *
- * @param drawio_xml - 新的 XML 内容
- * @returns 操作结果
- *
- * @example
- * const result = replaceDrawioXML('<mxfile>...</mxfile>');
- * if (result.success) {
- *   console.log('XML 已成功替换');
- * } else {
- *   console.error(result.error);
- * }
+ * 覆写 DrawIO XML 内容
  */
 export function replaceDrawioXML(drawio_xml: string): ReplaceXMLResult {
   if (typeof window === "undefined") {
@@ -190,7 +155,6 @@ export function replaceDrawioXML(drawio_xml: string): ReplaceXMLResult {
     };
   }
 
-  // 验证 XML 格式
   const validation = validateXML(drawio_xml);
   if (!validation.valid) {
     return {
@@ -201,7 +165,6 @@ export function replaceDrawioXML(drawio_xml: string): ReplaceXMLResult {
   }
 
   try {
-    // 保存到 localStorage（自动解码 base64）
     saveDrawioXML(drawio_xml);
 
     return {
@@ -217,159 +180,4 @@ export function replaceDrawioXML(drawio_xml: string): ReplaceXMLResult {
   }
 }
 
-/**
- * 3. 批量精准替换 XML 内容
- *
- * 对每个 search-replace 对进行全局替换，替换所有匹配的内容
- *
- * @param replacements - 替换对数组，每个对象包含 search 和 replace 字段
- * @returns 详细的批量替换结果报告
- *
- * @example
- * const result = batchReplaceDrawioXML([
- *   { search: 'oldText1', replace: 'newText1' },
- *   { search: 'oldText2', replace: 'newText2' }
- * ]);
- * console.log(`成功替换 ${result.successCount} 条`);
- * result.errors.forEach(err => console.log(`错误: ${err.reason}`));
- */
-export function batchReplaceDrawioXML(
-  replacements: Replacement[]
-): BatchReplaceResult {
-  if (typeof window === "undefined") {
-    return {
-      success: false,
-      message: "此函数只能在浏览器环境中使用",
-      totalRequested: replacements.length,
-      successCount: 0,
-      skippedCount: replacements.length,
-      errors: replacements.map((r, i) => ({
-        index: i,
-        search: r.search,
-        replace: r.replace,
-        reason: "不支持服务端环境",
-      })),
-    };
-  }
-
-  // 获取当前 XML
-  const getResult = getDrawioXML();
-  if (!getResult.success || !getResult.xml) {
-    return {
-      success: false,
-      message: getResult.error || "获取当前 XML 失败",
-      totalRequested: replacements.length,
-      successCount: 0,
-      skippedCount: replacements.length,
-      errors: replacements.map((r, i) => ({
-        index: i,
-        search: r.search,
-        replace: r.replace,
-        reason: "无法获取当前 XML 内容",
-      })),
-    };
-  }
-
-  let currentXml = getResult.xml;
-  const errors: ReplacementError[] = [];
-  let successCount = 0;
-
-  // 执行全局替换
-  replacements.forEach((replacement, index) => {
-    const { search, replace } = replacement;
-
-    // 检查搜索内容是否存在
-    if (!currentXml.includes(search)) {
-      errors.push({
-        index,
-        search,
-        replace,
-        reason: `未找到搜索内容 "${search}"`,
-      });
-      return;
-    }
-
-    // 使用全局替换替换所有匹配项
-    const regex = new RegExp(escapeRegExp(search), "g");
-    currentXml = currentXml.replace(regex, replace);
-    successCount++;
-  });
-
-  // 验证替换后的 XML 格式
-  if (successCount > 0) {
-    const validation = validateXML(currentXml);
-    if (!validation.valid) {
-      return {
-        success: false,
-        message: "替换后的 XML 格式验证失败",
-        totalRequested: replacements.length,
-        successCount: 0,
-        skippedCount: replacements.length,
-        errors: [
-          {
-            index: -1,
-            search: "",
-            replace: "",
-            reason: `XML 验证失败: ${validation.error}`,
-          },
-          ...errors,
-        ],
-      };
-    }
-
-    // 保存到 localStorage（自动解码 base64）并触发更新事件
-    try {
-      saveDrawioXML(currentXml);
-    } catch (error) {
-      return {
-        success: false,
-        message: "保存失败",
-        totalRequested: replacements.length,
-        successCount: 0,
-        skippedCount: replacements.length,
-        errors: [
-          {
-            index: -1,
-            search: "",
-            replace: "",
-            reason:
-              error instanceof Error ? error.message : "写入数据失败",
-          },
-          ...errors,
-        ],
-      };
-    }
-  }
-
-  // 生成结果报告
-  const skippedCount = errors.length;
-  const allSuccess = skippedCount === 0 && successCount > 0;
-
-  return {
-    success: allSuccess,
-    message: allSuccess
-      ? `成功替换 ${successCount} 条`
-      : successCount > 0
-      ? `部分成功：成功替换 ${successCount} 条，失败 ${skippedCount} 条`
-      : `所有替换均失败，失败 ${skippedCount} 条`,
-    totalRequested: replacements.length,
-    successCount,
-    skippedCount,
-    errors,
-  };
-}
-
-/**
- * 辅助函数：转义正则表达式特殊字符
- *
- * @param string - 需要转义的字符串
- * @returns 转义后的字符串
- */
-function escapeRegExp(string: string): string {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-/**
- * 导出事件名称常量，供组件监听使用
- */
 export { UPDATE_EVENT };

--- a/app/lib/drawio-xml-service.ts
+++ b/app/lib/drawio-xml-service.ts
@@ -1,0 +1,534 @@
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
+import { select } from 'xpath';
+
+import { executeToolOnClient } from './tool-executor';
+import type {
+  DrawioEditBatchRequest,
+  DrawioEditBatchResult,
+  DrawioEditOperation,
+  DrawioQueryResult,
+  DrawioReadResult,
+  InsertElementOperation,
+  InsertPosition,
+  ReplaceElementOperation,
+  SetAttributeOperation,
+  SetTextContentOperation,
+  RemoveAttributeOperation,
+  RemoveElementOperation,
+} from '@/app/types/drawio-tools';
+import type {
+  GetXMLResult,
+  ReplaceXMLResult,
+} from '@/app/types/drawio-tools';
+
+const BASE64_PREFIX = 'data:image/svg+xml;base64,';
+
+export async function executeDrawioRead(xpathExpression?: string): Promise<DrawioReadResult> {
+  try {
+    const xml = await fetchDiagramXml();
+    const document = parseXml(xml);
+
+    if (!xpathExpression || xpathExpression.trim() === '') {
+      const element = document.documentElement;
+      if (!element) {
+        return {
+          success: true,
+          results: [],
+        };
+      }
+      const rootResult = convertNodeToResult(element);
+      return {
+        success: true,
+        results: rootResult ? [rootResult] : [],
+      };
+    }
+
+    let evaluation;
+    try {
+      evaluation = select(xpathExpression, document);
+    } catch (error) {
+      return {
+        success: false,
+        error: `Invalid XPath expression: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+
+    if (!Array.isArray(evaluation)) {
+      const scalar = toScalarString(evaluation);
+      return {
+        success: true,
+        results:
+          scalar !== undefined
+            ? [
+                {
+                  type: 'text',
+                  value: scalar,
+                  matched_xpath: xpathExpression ?? '',
+                },
+              ]
+            : [],
+      };
+    }
+
+    const results: DrawioQueryResult[] = [];
+    for (const node of evaluation) {
+      if (isDomNode(node)) {
+        const converted = convertNodeToResult(node);
+        if (converted) {
+          results.push(converted);
+        }
+      }
+    }
+
+    return {
+      success: true,
+      results,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : '未知错误',
+    };
+  }
+}
+
+export async function executeDrawioEditBatch(
+  request: DrawioEditBatchRequest
+): Promise<DrawioEditBatchResult> {
+  const { operations } = request;
+
+  if (!operations.length) {
+    return {
+      success: true,
+      operations_applied: 0,
+    };
+  }
+
+  let document: Document;
+
+  try {
+    const xml = await fetchDiagramXml();
+    document = parseXml(xml);
+  } catch (error) {
+    return {
+      success: false,
+      operation_index: 0,
+      error: error instanceof Error ? error.message : '无法获取当前图表 XML',
+    };
+  }
+
+  for (let index = 0; index < operations.length; index++) {
+    const operation = operations[index];
+    try {
+      applyOperation(document, operation);
+    } catch (error) {
+      return {
+        success: false,
+        operation_index: index,
+        error: error instanceof Error ? error.message : '未知错误',
+      };
+    }
+  }
+
+  const serializer = new XMLSerializer();
+  const updatedXml = serializer.serializeToString(document);
+
+  const replaceResult = (await executeToolOnClient(
+    'replace_drawio_xml',
+    { drawio_xml: updatedXml },
+    30000
+  )) as ReplaceXMLResult;
+
+  if (!replaceResult?.success) {
+    return {
+      success: false,
+      operation_index: operations.length,
+      error:
+        replaceResult?.error ||
+        replaceResult?.message ||
+        '前端替换 XML 失败',
+    };
+  }
+
+  return {
+    success: true,
+    operations_applied: operations.length,
+  };
+}
+
+async function fetchDiagramXml(): Promise<string> {
+  const response = (await executeToolOnClient(
+    'get_drawio_xml',
+    {},
+    15000
+  )) as GetXMLResult;
+
+  if (!response?.success || typeof response.xml !== 'string') {
+    throw new Error(response?.error || '无法获取当前 DrawIO XML');
+  }
+
+  return decodeDiagramXml(response.xml);
+}
+
+function decodeDiagramXml(payload: string): string {
+  const trimmed = payload.trim();
+
+  if (trimmed.startsWith('<')) {
+    return trimmed;
+  }
+
+  let base64Content = trimmed;
+  if (trimmed.startsWith(BASE64_PREFIX)) {
+    base64Content = trimmed.slice(BASE64_PREFIX.length);
+  }
+
+  try {
+    const decoded = Buffer.from(base64Content, 'base64').toString('utf-8');
+    if (!decoded.trim().startsWith('<')) {
+      throw new Error('解码结果不是合法的 XML');
+    }
+    return decoded;
+  } catch (error) {
+    throw new Error(
+      error instanceof Error
+        ? `Base64 解码失败: ${error.message}`
+        : 'Base64 解码失败'
+    );
+  }
+}
+
+function parseXml(xml: string): Document {
+  const parser = new DOMParser();
+  const document = parser.parseFromString(xml, 'text/xml');
+  const parseErrors = document.getElementsByTagName('parsererror');
+  if (parseErrors.length > 0) {
+    throw new Error(parseErrors[0].textContent || 'XML 解析失败');
+  }
+  return document;
+}
+
+function convertNodeToResult(node: Node): DrawioQueryResult | null {
+  const serializer = new XMLSerializer();
+  const matchedXPath = buildXPathForNode(node);
+
+  switch (node.nodeType) {
+    case node.ELEMENT_NODE: {
+      const element = node as Element;
+      const attributes: Record<string, string> = {};
+      for (let i = 0; i < element.attributes.length; i++) {
+        const attribute = element.attributes.item(i);
+        if (attribute) {
+          attributes[attribute.name] = attribute.value;
+        }
+      }
+      return {
+        type: 'element',
+        tag_name: element.tagName,
+        attributes,
+        xml_string: serializer.serializeToString(element),
+        matched_xpath: matchedXPath,
+      };
+    }
+    case node.ATTRIBUTE_NODE: {
+      const attr = node as Attr;
+      return {
+        type: 'attribute',
+        name: attr.name,
+        value: attr.value,
+        matched_xpath: matchedXPath,
+      };
+    }
+    case node.TEXT_NODE: {
+      return {
+        type: 'text',
+        value: node.nodeValue ?? '',
+        matched_xpath: matchedXPath,
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+function applyOperation(document: Document, operation: DrawioEditOperation): void {
+  switch (operation.type) {
+    case 'set_attribute':
+      setAttribute(document, operation);
+      break;
+    case 'remove_attribute':
+      removeAttribute(document, operation);
+      break;
+    case 'insert_element':
+      insertElement(document, operation);
+      break;
+    case 'remove_element':
+      removeElement(document, operation);
+      break;
+    case 'replace_element':
+      replaceElement(document, operation);
+      break;
+    case 'set_text_content':
+      setTextContent(document, operation);
+      break;
+    default:
+      throw new Error(`未知操作类型: ${(operation as { type: string }).type}`);
+  }
+}
+
+function setAttribute(document: Document, operation: SetAttributeOperation): void {
+  const nodes = selectNodes(document, operation.xpath);
+
+  if (nodes.length === 0) {
+    if (operation.allow_no_match) {
+      return;
+    }
+    throw new Error(`XPath '${operation.xpath}' did not match any elements.`);
+  }
+
+  for (const node of nodes) {
+    if (node.nodeType !== node.ELEMENT_NODE) {
+      throw new Error(`XPath '${operation.xpath}' 匹配的节点不是元素。`);
+    }
+    (node as Element).setAttribute(operation.key, operation.value);
+  }
+}
+
+function removeAttribute(document: Document, operation: RemoveAttributeOperation): void {
+  const nodes = selectNodes(document, operation.xpath);
+
+  if (nodes.length === 0) {
+    if (operation.allow_no_match) {
+      return;
+    }
+    throw new Error(`XPath '${operation.xpath}' did not match any elements.`);
+  }
+
+  for (const node of nodes) {
+    if (node.nodeType !== node.ELEMENT_NODE) {
+      throw new Error(`XPath '${operation.xpath}' 匹配的节点不是元素。`);
+    }
+    (node as Element).removeAttribute(operation.key);
+  }
+}
+
+function insertElement(document: Document, operation: InsertElementOperation): void {
+  const targets = selectNodes(document, operation.target_xpath);
+
+  if (targets.length === 0) {
+    if (operation.allow_no_match) {
+      return;
+    }
+    throw new Error(`XPath '${operation.target_xpath}' did not match any elements.`);
+  }
+
+  const position: InsertPosition = operation.position ?? 'append_child';
+
+  for (const target of targets) {
+    const newNode = createElementFromXml(document, operation.new_xml);
+
+    switch (position) {
+      case 'append_child': {
+        if (target.nodeType !== target.ELEMENT_NODE) {
+          throw new Error(`XPath '${operation.target_xpath}' 仅支持元素节点作为父节点。`);
+        }
+        (target as Element).appendChild(newNode);
+        break;
+      }
+      case 'prepend_child': {
+        if (target.nodeType !== target.ELEMENT_NODE) {
+          throw new Error(`XPath '${operation.target_xpath}' 仅支持元素节点作为父节点。`);
+        }
+        const element = target as Element;
+        element.insertBefore(newNode, element.firstChild);
+        break;
+      }
+      case 'before': {
+        const parent = target.parentNode;
+        if (!parent) {
+          throw new Error('目标节点没有父节点，无法执行 before 插入。');
+        }
+        parent.insertBefore(newNode, target);
+        break;
+      }
+      case 'after': {
+        const parent = target.parentNode;
+        if (!parent) {
+          throw new Error('目标节点没有父节点，无法执行 after 插入。');
+        }
+        parent.insertBefore(newNode, target.nextSibling);
+        break;
+      }
+      default:
+        throw new Error(`未知的插入位置: ${String(position)}`);
+    }
+  }
+}
+
+function removeElement(document: Document, operation: RemoveElementOperation): void {
+  const nodes = selectNodes(document, operation.xpath);
+
+  if (nodes.length === 0) {
+    if (operation.allow_no_match) {
+      return;
+    }
+    throw new Error(`XPath '${operation.xpath}' did not match any elements.`);
+  }
+
+  for (const node of nodes) {
+    const parent = node.parentNode;
+    if (!parent) {
+      throw new Error('无法删除根节点。');
+    }
+    parent.removeChild(node);
+  }
+}
+
+function replaceElement(document: Document, operation: ReplaceElementOperation): void {
+  const nodes = selectNodes(document, operation.xpath);
+
+  if (nodes.length === 0) {
+    if (operation.allow_no_match) {
+      return;
+    }
+    throw new Error(`XPath '${operation.xpath}' did not match any elements.`);
+  }
+
+  for (const node of nodes) {
+    const parent = node.parentNode;
+    if (!parent) {
+      throw new Error('无法替换根节点。');
+    }
+    const replacement = createElementFromXml(document, operation.new_xml);
+    parent.replaceChild(replacement, node);
+  }
+}
+
+function setTextContent(document: Document, operation: SetTextContentOperation): void {
+  const nodes = selectNodes(document, operation.xpath);
+
+  if (nodes.length === 0) {
+    if (operation.allow_no_match) {
+      return;
+    }
+    throw new Error(`XPath '${operation.xpath}' did not match any elements.`);
+  }
+
+  for (const node of nodes) {
+    if (node.nodeType !== node.ELEMENT_NODE) {
+      throw new Error(`XPath '${operation.xpath}' 匹配的节点不是元素。`);
+    }
+
+    const element = node as Element;
+    while (element.firstChild) {
+      element.removeChild(element.firstChild);
+    }
+    element.appendChild(document.createTextNode(operation.value));
+  }
+}
+
+function createElementFromXml(document: Document, xml: string): Element {
+  const parser = new DOMParser();
+  const fragment = parser.parseFromString(xml, 'text/xml');
+  const parseErrors = fragment.getElementsByTagName('parsererror');
+  if (parseErrors.length > 0) {
+    throw new Error(parseErrors[0].textContent || 'new_xml 解析失败');
+  }
+  const element = fragment.documentElement;
+  if (!element) {
+    throw new Error('new_xml 必须包含一个元素节点');
+  }
+
+  if (typeof document.importNode === 'function') {
+    return document.importNode(element, true) as Element;
+  }
+
+  return element.cloneNode(true) as Element;
+}
+
+function selectNodes(document: Document, expression: string): Node[] {
+  let evaluation;
+  try {
+    evaluation = select(expression, document);
+  } catch (error) {
+    throw new Error(
+      `Invalid XPath expression: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  if (!Array.isArray(evaluation)) {
+    return [];
+  }
+
+  return evaluation.filter(isDomNode);
+}
+
+function isDomNode(value: unknown): value is Node {
+  return Boolean(value && typeof (value as Node).nodeType === 'number');
+}
+
+function toScalarString(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (isDomNode(value)) {
+    return value.textContent ?? undefined;
+  }
+  return undefined;
+}
+
+function buildXPathForNode(node: Node): string {
+  switch (node.nodeType) {
+    case node.DOCUMENT_NODE:
+      return '';
+    case node.ELEMENT_NODE: {
+      const element = node as Element;
+      const parent = element.parentNode;
+      const index = getElementIndex(element);
+      const segment = index > 1 ? `${element.tagName}[${index}]` : element.tagName;
+      const parentPath = parent ? buildXPathForNode(parent) : '';
+      return `${parentPath}/${segment}`;
+    }
+    case node.ATTRIBUTE_NODE: {
+      const attr = node as Attr;
+      const owner = attr.ownerElement;
+      const ownerPath = owner ? buildXPathForNode(owner) : '';
+      return `${ownerPath}/@${attr.name}`;
+    }
+    case node.TEXT_NODE: {
+      const parent = node.parentNode;
+      const parentPath = parent ? buildXPathForNode(parent) : '';
+      const index = getTextNodeIndex(node);
+      const segment = index > 1 ? `text()[${index}]` : 'text()';
+      return `${parentPath}/${segment}`;
+    }
+    default:
+      return '';
+  }
+}
+
+function getElementIndex(element: Element): number {
+  const parent = element.parentNode;
+  if (!parent) {
+    return 1;
+  }
+  const siblings = Array.from(parent.childNodes).filter(
+    (node) => node.nodeType === node.ELEMENT_NODE && (node as Element).tagName === element.tagName
+  );
+  const position = siblings.indexOf(element);
+  return position >= 0 ? position + 1 : 1;
+}
+
+function getTextNodeIndex(node: Node): number {
+  const parent = node.parentNode;
+  if (!parent) {
+    return 1;
+  }
+  const textSiblings = Array.from(parent.childNodes).filter(
+    (child): child is ChildNode => child.nodeType === child.TEXT_NODE
+  );
+  const position = textSiblings.indexOf(node as ChildNode);
+  return position >= 0 ? position + 1 : 1;
+}

--- a/app/lib/llm-config.ts
+++ b/app/lib/llm-config.ts
@@ -1,22 +1,26 @@
 import { LLMConfig, ProviderType } from "@/app/types/chat";
 
-export const DEFAULT_SYSTEM_PROMPT = `你是一个专业的 DrawIO XML 绘制助手。你的任务是帮助用户创建、修改和优化 DrawIO 图表。
+export const DEFAULT_SYSTEM_PROMPT = `你是一个专业的 DrawIO XML 绘制助手，负责通过 Socket.IO + XPath 工具链安全地读取和编辑图表。
 
-你需要：
-1. 理解用户对图表的描述和需求
-2. 生成或修改符合 DrawIO XML 格式的代码
-3. 确保 XML 结构正确，包含必要的元数据、样式和连接关系
-4. 提供清晰的节点布局和美观的视觉效果
-5. 解释你所做的修改和设计决策
+### 核心准则
+1. **无推断 (No Inference)**：永远不要猜测或重写 XML 结构，不要对 style、geometry 等领域字段做额外的“智能”解析。
+2. **XPath 驱动**：所有读取或写入都必须先通过标准 XPath 精确定位目标，再结合工具返回的 matched_xpath 字段确认结果。
+3. **原子性**：批量编辑只能通过 \`drawio_edit_batch\` 完成；若任意操作失败，必须让整批回滚，不得在外部自行补救。
+4. **最少读写**：先用 \`drawio_read\` 获取所需元素或属性，再决定是否编辑，避免一次批量里混入无关操作。
 
-DrawIO XML 基本规范：
-- 使用 <mxGraphModel> 作为根元素
-- 使用 <mxCell> 定义节点和连接
-- 使用 style 属性定义样式（形状、颜色、字体等）
-- 使用 mxGeometry 定义位置和大小
-- 保持 ID 的唯一性
+### 工具使用说明
+- \`drawio_read\`：可选传入 XPath，返回命中的元素/属性/文本及其 matched_xpath，便于直接用于后续操作。
+- \`drawio_edit_batch\`：传入 operations 数组，按顺序执行。每个操作需要提供 XPath/target_xpath 与必要的字段，必要时设置 \`allow_no_match: true\` 避免错误中断。
+- 支持的操作：set_attribute、remove_attribute、insert_element、remove_element、replace_element、set_text_content。
 
-请始终确保生成的 XML 可以被 DrawIO 正确解析和渲染。`;
+### DrawIO XML 规范提醒
+- 根结构：<mxGraphModel> 下的 <root> 与 <mxCell>
+- 元素定位：使用唯一 id 或层级 XPath，保持属性大小写正确
+- 样式写法：整体写入 style 字符串，不拆分字段
+- 几何属性：通过 <mxGeometry> 节点设置 x/y/width/height
+- ID 唯一：新增元素必须赋予唯一 id
+
+确保输出的 XML 始终可以被 DrawIO 正确解析与渲染，并在回复中解释你的思考过程与操作理由。`;
 
 export const DEFAULT_API_URL = "https://api.deepseek.com/v1";
 

--- a/app/types/AGENTS.md
+++ b/app/types/AGENTS.md
@@ -37,11 +37,12 @@ Socket.IO 通讯协议的类型定义。
 - 全局 Socket.IO 客户端类型
 - 环境变量类型声明
 - 扩展的 Window 对象属性
+- `declare module 'xpath'`：为第三方库补充最小化声明
 
 ### drawio-tools.ts
-DrawIO XML 操作工具的完整类型定义。
+DrawIO XML 操作的完整类型定义。
 
-#### 核心接口
+#### 前端桥接类型
 
 **GetXMLResult** - 获取 XML 的返回结果
 ```typescript
@@ -61,42 +62,60 @@ export interface ReplaceXMLResult {
 }
 ```
 
-**Replacement** - 批量替换的单个替换对
-```typescript
-export interface Replacement {
-  search: string;    // 查找文本
-  replace: string;   // 替换文本
-}
-```
-
-**ReplacementError** - 批量替换中跳过项的错误详情
-```typescript
-export interface ReplacementError {
-  index: number;     // 错误项索引
-  search: string;    // 查找文本
-  replace: string;   // 替换文本
-  reason: string;    // 跳过原因
-}
-```
-
-**BatchReplaceResult** - 批量替换的返回结果
-```typescript
-export interface BatchReplaceResult {
-  success: boolean;
-  message: string;
-  totalRequested: number;    // 总请求数
-  successCount: number;      // 成功数
-  skippedCount: number;      // 跳过数
-  errors: ReplacementError[]; // 错误详情
-}
-```
-
 **XMLValidationResult** - XML 验证结果
 ```typescript
 export interface XMLValidationResult {
   valid: boolean;
   error?: string;
 }
+```
+
+#### drawio_read 查询结果
+
+**DrawioQueryResult** - 统一的查询结果联合类型（包含 matched_xpath 字段，指向命中的节点路径）
+```typescript
+export type DrawioQueryResult =
+  | { type: 'element'; tag_name: string; attributes: Record<string, string>; xml_string: string; matched_xpath: string }
+  | { type: 'attribute'; name: string; value: string; matched_xpath: string }
+  | { type: 'text'; value: string; matched_xpath: string };
+```
+
+**DrawioReadResult** - 查询响应
+```typescript
+export interface DrawioReadResult {
+  success: boolean;
+  results?: DrawioQueryResult[];
+  error?: string;
+}
+```
+
+#### drawio_edit_batch 操作定义
+
+所有操作共享 `allow_no_match?: boolean` 标志，未匹配节点时根据该标志决定是否视为成功跳过。
+
+- **SetAttributeOperation** (`type: 'set_attribute'`)
+- **RemoveAttributeOperation** (`type: 'remove_attribute'`)
+- **InsertElementOperation** (`type: 'insert_element'`, `target_xpath`, `new_xml`, `position`) 
+- **RemoveElementOperation** (`type: 'remove_element'`, `xpath`)
+- **ReplaceElementOperation** (`type: 'replace_element'`, `xpath`, `new_xml`)
+- **SetTextContentOperation** (`type: 'set_text_content'`, `xpath`, `value`)
+
+联合类型示例：
+```typescript
+export type DrawioEditOperation =
+  | SetAttributeOperation
+  | RemoveAttributeOperation
+  | InsertElementOperation
+  | RemoveElementOperation
+  | ReplaceElementOperation
+  | SetTextContentOperation;
+```
+
+**DrawioEditBatchResult** - 批量编辑返回结构
+```typescript
+export type DrawioEditBatchResult =
+  | { success: true; operations_applied: number }
+  | { success: false; operation_index: number; error: string };
 ```
 
 ## 类型设计原则
@@ -107,7 +126,7 @@ export interface XMLValidationResult {
 
 ### 2. 详细错误信息
 - 每个错误都包含具体的描述信息
-- 批量操作提供单项错误追踪
+- 批量操作保留触发失败的操作索引
 
 ### 3. 类型安全
 - 使用严格的类型检查
@@ -125,22 +144,28 @@ export interface XMLValidationResult {
 import type {
   GetXMLResult,
   ReplaceXMLResult,
-  BatchReplaceResult,
-  Replacement
+  DrawioReadResult,
+  DrawioEditOperation,
+  DrawioEditBatchResult,
 } from "./drawio-tools";
+import {
+  executeDrawioRead,
+  executeDrawioEditBatch,
+} from "../lib/drawio-xml-service";
 
-// 类型安全的函数调用
-async function handleXmlOperations() {
-  const result: GetXMLResult = await getDrawioXML();
+async function demo() {
+  const read: DrawioReadResult = await executeDrawioRead("//mxCell[@id='cat-head']");
 
-  if (result.success && result.xml) {
-    const replacements: Replacement[] = [
-      { search: "旧文本", replace: "新文本" }
-    ];
+  const editOperations: DrawioEditOperation[] = [
+    {
+      type: 'set_attribute',
+      xpath: "//mxCell[@id='cat-head']",
+      key: 'value',
+      value: 'Cat Head',
+    },
+  ];
 
-    const batchResult: BatchReplaceResult =
-      await batchReplaceDrawioXML(replacements);
-  }
+  const result: DrawioEditBatchResult = await executeDrawioEditBatch({ operations: editOperations });
 }
 ```
 
@@ -154,6 +179,6 @@ async function handleXmlOperations() {
 
 ### 类型命名规范
 - **接口**: PascalCase (如 `GetXMLResult`)
-- **类型别名**: PascalCase (如 `EventHandler`)
+- **类型别名**: PascalCase (如 `DrawioEditOperation`)
 - **枚举**: PascalCase (如 `ThemeMode`)
 - **常量**: camelCase (如 `storageKey`)

--- a/app/types/drawio-tools.ts
+++ b/app/types/drawio-tools.ts
@@ -3,7 +3,7 @@
  */
 
 /**
- * 获取 XML 的返回结果
+ * 获取 XML 的返回结果（前端存储访问）
  */
 export interface GetXMLResult {
   success: boolean;
@@ -12,7 +12,7 @@ export interface GetXMLResult {
 }
 
 /**
- * 替换 XML 的返回结果
+ * 替换 XML 的返回结果（前端存储访问）
  */
 export interface ReplaceXMLResult {
   success: boolean;
@@ -21,39 +21,122 @@ export interface ReplaceXMLResult {
 }
 
 /**
- * 批量替换的单个替换对
- */
-export interface Replacement {
-  search: string;
-  replace: string;
-}
-
-/**
- * 批量替换中失败项的错误详情
- */
-export interface ReplacementError {
-  index: number;
-  search: string;
-  replace: string;
-  reason: string;
-}
-
-/**
- * 批量替换的返回结果
- */
-export interface BatchReplaceResult {
-  success: boolean;
-  message: string;
-  totalRequested: number;
-  successCount: number;
-  skippedCount: number;
-  errors: ReplacementError[];
-}
-
-/**
  * XML 验证结果
  */
 export interface XMLValidationResult {
   valid: boolean;
   error?: string;
+}
+
+/**
+ * drawio_read 查询结果的统一类型
+ */
+export type DrawioQueryResult =
+  | DrawioElementResult
+  | DrawioAttributeResult
+  | DrawioTextResult;
+
+interface DrawioQueryResultBase {
+  matched_xpath: string;
+}
+
+export interface DrawioElementResult extends DrawioQueryResultBase {
+  type: 'element';
+  tag_name: string;
+  attributes: Record<string, string>;
+  xml_string: string;
+}
+
+export interface DrawioAttributeResult extends DrawioQueryResultBase {
+  type: 'attribute';
+  name: string;
+  value: string;
+}
+
+export interface DrawioTextResult extends DrawioQueryResultBase {
+  type: 'text';
+  value: string;
+}
+
+export interface DrawioReadResult {
+  success: boolean;
+  results?: DrawioQueryResult[];
+  error?: string;
+}
+
+/**
+ * drawio_edit_batch 批量操作定义
+ */
+interface OperationBase {
+  allow_no_match?: boolean;
+}
+
+export interface SetAttributeOperation extends OperationBase {
+  type: 'set_attribute';
+  xpath: string;
+  key: string;
+  value: string;
+}
+
+export interface RemoveAttributeOperation extends OperationBase {
+  type: 'remove_attribute';
+  xpath: string;
+  key: string;
+}
+
+export type InsertPosition =
+  | 'append_child'
+  | 'prepend_child'
+  | 'before'
+  | 'after';
+
+export interface InsertElementOperation extends OperationBase {
+  type: 'insert_element';
+  target_xpath: string;
+  new_xml: string;
+  position?: InsertPosition;
+}
+
+export interface RemoveElementOperation extends OperationBase {
+  type: 'remove_element';
+  xpath: string;
+}
+
+export interface ReplaceElementOperation extends OperationBase {
+  type: 'replace_element';
+  xpath: string;
+  new_xml: string;
+}
+
+export interface SetTextContentOperation extends OperationBase {
+  type: 'set_text_content';
+  xpath: string;
+  value: string;
+}
+
+export type DrawioEditOperation =
+  | SetAttributeOperation
+  | RemoveAttributeOperation
+  | InsertElementOperation
+  | RemoveElementOperation
+  | ReplaceElementOperation
+  | SetTextContentOperation;
+
+export interface DrawioEditBatchRequest {
+  operations: DrawioEditOperation[];
+}
+
+export type DrawioEditBatchResult =
+  | DrawioEditBatchSuccess
+  | DrawioEditBatchError;
+
+export interface DrawioEditBatchSuccess {
+  success: true;
+  operations_applied: number;
+}
+
+export interface DrawioEditBatchError {
+  success: false;
+  operation_index: number;
+  error: string;
 }

--- a/app/types/global.d.ts
+++ b/app/types/global.d.ts
@@ -46,4 +46,15 @@ declare global {
   }
 }
 
+declare module 'xpath' {
+  import type { Document, Node } from '@xmldom/xmldom';
+
+  export type XPathValue = Node | string | number | boolean;
+
+  export function select(
+    expression: string,
+    node: Node | Document
+  ): XPathValue | XPathValue[];
+}
+
 export {};

--- a/app/types/socket-protocol.ts
+++ b/app/types/socket-protocol.ts
@@ -9,7 +9,7 @@
  */
 export interface ToolCallRequest {
   requestId: string;
-  toolName: 'get_drawio_xml' | 'replace_drawio_xml' | 'batch_replace_drawio_xml';
+  toolName: 'get_drawio_xml' | 'replace_drawio_xml';
   input: Record<string, unknown>;
   timeout: number;
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@heroui/react": "3.0.0-alpha.35",
     "@heroui/styles": "3.0.0-alpha.35",
     "@tailwindcss/postcss": "^4.1.16",
+    "@xmldom/xmldom": "^0.8.11",
     "ai": "^5.0.86",
     "electron-store": "^11.0.2",
     "next": "^15.5.6",
@@ -41,6 +42,7 @@
     "tailwind-variants": "^3.1.1",
     "tailwindcss": "^4.1.16",
     "uuid": "^11.0.6",
+    "xpath": "^0.0.34",
     "zod": "^4.1.12"
   },
   "devDependencies": {
@@ -49,6 +51,7 @@
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
     "@types/uuid": "^10.0.0",
+    "@types/xmldom": "^0.1.34",
     "concurrently": "^8.2.2",
     "electron": "^38.5.0",
     "electron-builder": "^24.13.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.1.16
         version: 4.1.16
+      '@xmldom/xmldom':
+        specifier: ^0.8.11
+        version: 0.8.11
       ai:
         specifier: ^5.0.86
         version: 5.0.86(zod@4.1.12)
@@ -68,6 +71,9 @@ importers:
       uuid:
         specifier: ^11.0.6
         version: 11.1.0
+      xpath:
+        specifier: ^0.0.34
+        version: 0.0.34
       zod:
         specifier: ^4.1.12
         version: 4.1.12
@@ -87,6 +93,9 @@ importers:
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
+      '@types/xmldom':
+        specifier: ^0.1.34
+        version: 0.1.34
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
@@ -1401,6 +1410,9 @@ packages:
 
   '@types/verror@1.10.11':
     resolution: {integrity: sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==}
+
+  '@types/xmldom@0.1.34':
+    resolution: {integrity: sha512-7eZFfxI9XHYjJJuugddV6N5YNeXgQE1lArWOcd1eCOKWb/FGs5SIjacSYuEJuwhsGS3gy4RuZ5EUIcqYscuPDA==}
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
@@ -3926,6 +3938,10 @@ packages:
     resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
     engines: {node: '>=0.4.0'}
 
+  xpath@0.0.34:
+    resolution: {integrity: sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA==}
+    engines: {node: '>=0.6.0'}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -5688,6 +5704,8 @@ snapshots:
 
   '@types/verror@1.10.11':
     optional: true
+
+  '@types/xmldom@0.1.34': {}
 
   '@types/yauzl@2.10.3':
     dependencies:
@@ -8934,6 +8952,8 @@ snapshots:
   xmlbuilder@15.1.1: {}
 
   xmlhttprequest-ssl@2.1.2: {}
+
+  xpath@0.0.34: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## Summary
- refresh the default DrawIO system prompt to document the socket-driven XPath workflow and matched_xpath responses
- tighten drawio_edit_batch validation without literal consts and expose matched_xpath for drawio_read results
- update docs/types accordingly and add @types/xmldom to satisfy TypeScript tooling

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_6909c5f835548328aec57e35811fc0a5