### PR TITLE
Add selected cell count indicator to bottom bar

### DIFF
--- a/app/components/BottomBar.tsx
+++ b/app/components/BottomBar.tsx
@@ -8,6 +8,7 @@ interface BottomBarProps {
   onSave?: () => void;
   onLoad?: () => void;
   activeSidebar?: "none" | "settings" | "chat";
+  selectionCount?: number;
 }
 
 export default function BottomBar({
@@ -16,6 +17,7 @@ export default function BottomBar({
   onSave,
   onLoad,
   activeSidebar = "none",
+  selectionCount = 0,
 }: BottomBarProps) {
   const handleGithubClick = () => {
     // 在 Electron 中打开外部链接
@@ -29,6 +31,8 @@ export default function BottomBar({
 
   return (
     <div className="bottom-bar">
+      <div className="bottom-bar-selection">选中了 {selectionCount} 个对象</div>
+
       <Button
         variant="secondary"
         size="md"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,6 +13,7 @@ export default function Home() {
   const [currentXml, setCurrentXml] = useState<string>("");
   const [settings, setSettings] = useState({ defaultPath: "" });
   const [activeSidebar, setActiveSidebar] = useState<"none" | "settings" | "chat">("none");
+  const [selectionCount, setSelectionCount] = useState(0);
 
   // 初始化 Socket.IO 连接
   const { isConnected } = useDrawioSocket();
@@ -160,6 +161,7 @@ export default function Home() {
         <DrawioEditorNative
           initialXml={diagramXml}
           onSave={handleAutoSave}
+          onSelectionChange={setSelectionCount}
         />
       </div>
 
@@ -178,6 +180,7 @@ export default function Home() {
         onSave={handleManualSave}
         onLoad={handleLoad}
         activeSidebar={activeSidebar}
+        selectionCount={selectionCount}
       />
     </main>
   );

--- a/app/styles/layout/container.css
+++ b/app/styles/layout/container.css
@@ -45,10 +45,17 @@
   border-top: 1px solid var(--border, #e5e7eb);
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: flex-start;
   padding: 0 1rem;
   gap: 0.75rem;
   z-index: 50;
+}
+
+.bottom-bar-selection {
+  font-size: 0.85rem;
+  color: var(--text-muted, #6b7280);
+  display: flex;
+  align-items: center;
 }
 
 .dark .bottom-bar {


### PR DESCRIPTION
## Summary
- capture DrawIO iframe selection change events and forward the count to the app state
- show the current selection count on the bottom bar and adjust its layout styling

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_690ae7b1511c8328b431aa9c93a5a8b2