### PR TITLE
优化 DrawIO XML 重载触发逻辑

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -53,7 +53,7 @@ export default function Home() {
   const handleAutoSave = (xml: string) => {
     setCurrentXml(xml);
     if (typeof window !== "undefined") {
-      saveDrawioXML(xml);
+      saveDrawioXML(xml, { notify: false });
     }
   };
 


### PR DESCRIPTION
## Summary
- 为保存工具新增 `notify` 选项，允许在自动保存时跳过 XML 更新事件
- 页面自动保存改为静默更新本地存储，避免正常编辑触发 iframe 重载

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_690ae7af12108328b3122b4e2ae2a709